### PR TITLE
feat: support theme config

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,30 @@
 export default defineNuxtConfig({
   modules: ["../src/module"],
-  pandacss: {},
+  pandacss: {
+    theme: {
+      tokens: {
+        colors: {
+          primary: { value: "#0FEE0F" },
+          secondary: { value: "#EE0F0F" },
+        },
+        fontSizes: {
+          "2xs": { value: "0.5rem" },
+          xs: { value: "0.75rem" },
+          sm: { value: "0.875rem" },
+          md: { value: "1rem" },
+          lg: { value: "1.125rem" },
+          xl: { value: "1.25rem" },
+          "2xl": { value: "1.5rem" },
+          "3xl": { value: "1.875rem" },
+          "4xl": { value: "2.25rem" },
+          "5xl": { value: "3rem" },
+          "6xl": { value: "3.75rem" },
+          "7xl": { value: "4.5rem" },
+          "8xl": { value: "6rem" },
+          "9xl": { value: "8rem" },
+        },
+      },
+    },
+  },
   devtools: { enabled: true },
 });

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -3,5 +3,7 @@ import { css } from "styled-system/css";
 </script>
 
 <template>
-  <div :class="css({ fontSize: '5xl', fontWeight: 'bold' })">Hello 🐼!</div>
+  <div :class="css({ fontSize: '5xl', fontWeight: 'bold', color: 'primary' })">
+    Hello 🐼!
+  </div>
 </template>

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -16,22 +16,39 @@ describe("basic test", async () => {
 
     expect(nuxt.vfs["#build/panda.config"]).toMatchInlineSnapshot(`
       "
-        import { defineConfig } from \\"@pandacss/dev\\"
+      import { defineConfig } from \\"@pandacss/dev\\"
        
       export default defineConfig({
-       // Whether to use css reset
-       preflight: true,
+        theme: {
+        \\"tokens\\": {
+          \\"colors\\": {
+            \\"primary\\": {
+              \\"value\\": \\"#0FEE0F\\"
+            },
+            \\"secondary\\": {
+              \\"value\\": \\"#EE0F0F\\"
+            }
+          },
+          \\"fonts\\": {
+            \\"body\\": {
+              \\"value\\": \\"system-ui, sans-serif\\"
+            }
+          }
+        }
+      },
+        // Whether to use css reset
+        preflight: true,
        
-       // Where to look for your css declarations
-       include: [\\"/Users/wattanx/repo/nuxt-pandacss/test/fixtures/basic/components/**/*.{js,jsx,ts,tsx,vue}\\",
-       \\"/Users/wattanx/repo/nuxt-pandacss/test/fixtures/basic/pages/**/*.{js,jsx,ts,tsx,vue}\\"],
+        // Where to look for your css declarations
+        include: [\\"/Users/wattanx/repo/nuxt-pandacss/test/fixtures/basic/components/**/*.{js,jsx,ts,tsx,vue}\\",
+        \\"/Users/wattanx/repo/nuxt-pandacss/test/fixtures/basic/pages/**/*.{js,jsx,ts,tsx,vue}\\"],
        
-       // Files to exclude
-       exclude: [],
+        // Files to exclude
+        exclude: [],
        
-       // The output directory for your css system
-       outdir: \\"styled-system\\",
-       cwd: \\"/Users/wattanx/repo/nuxt-pandacss/test/fixtures/basic/.nuxt\\",
+        // The output directory for your css system
+        outdir: \\"styled-system\\",
+        cwd: \\"/Users/wattanx/repo/nuxt-pandacss/test/fixtures/basic/.nuxt\\",
       })"
     `);
   });

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,7 +1,18 @@
-import MyModule from '../../../src/module'
+import MyModule from "../../../src/module";
 
 export default defineNuxtConfig({
-  modules: [
-    MyModule
-  ]
-})
+  modules: [MyModule],
+  pandacss: {
+    theme: {
+      tokens: {
+        colors: {
+          primary: { value: "#0FEE0F" },
+          secondary: { value: "#EE0F0F" },
+        },
+        fonts: {
+          body: { value: "system-ui, sans-serif" },
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
Support for functionality that allows theme to be configured in `nuxt.config.ts`.

```ts
export default defineNuxtConfig({
  modules: ['@wattanx/nuxt-pandacss'],
  pandacss: {
    theme: {
      tokens: {
        colors: {
          primary: { value: "#0FEE0F" },
          secondary: { value: "#EE0F0F" },
        },
      },
    },
  }
})
```