### PR TITLE
feat: add 'cssPath' options for Nuxt module & add resolver

### DIFF
--- a/playground/css/global.css
+++ b/playground/css/global.css
@@ -1,0 +1,1 @@
+@layer reset, base, tokens, recipes, utilities;

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -26,6 +26,7 @@ export default defineNuxtConfig({
       },
     },
     jsxFramework: "vue",
+    cssPath: "@/css/global.css",
   },
   devtools: { enabled: true },
 });

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,6 +17,7 @@ export interface ModuleOptions extends Config {
   configPath?: string;
   /**
    * The path of the Panda CSS file.
+   * If the file does not exist, it will be created automatically.
    * @default '<buildDir>/panda.css'
    * @example '@/assets/css/global.css'
    */
@@ -70,6 +71,7 @@ export default defineNuxtModule<ModuleOptions>({
       configPath,
     };
 
+    // Add CSS file
     const { resolvedCSSPath, loggerMessage } = await resolveCSSPath(
       options.cssPath,
       nuxt

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,7 +17,8 @@ export interface ModuleOptions extends Config {
   configPath?: string;
   /**
    * The path of the Panda CSS file.
-   * @default '@/assets/css/global.css'
+   * @default '<buildDir>/panda.css'
+   * @example '@/assets/css/global.css'
    */
   cssPath?: string;
 }
@@ -37,7 +38,7 @@ export default defineNuxtModule<ModuleOptions>({
     exclude: [],
     outdir: "styled-system",
     cwd: nuxt.options.buildDir,
-    cssPath: `@/${nuxt.options.dir.assets}/css/global.css`,
+    cssPath: `${nuxt.options.buildDir}/panda.css`,
   }),
   async setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url);
@@ -120,7 +121,7 @@ function addPandaConfigTemplate(cwd: string, options: ModuleOptions) {
     filename: "panda.config.mjs",
     getContents: () => `
 import { defineConfig } from "@pandacss/dev"
- 
+
 export default defineConfig(${JSON.stringify({ ...options, cwd }, null, 2)})`,
     write: true,
   }).dst;

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -5,7 +5,7 @@ import { relative } from "node:path";
 
 /**
  *
- * @param cssPath
+ * @param cssPath - ModuleOptions.cssPath
  * @param nuxt
  * @returns resolvedCSSPath
  * @returns loggerMessage

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,0 +1,46 @@
+import { createResolver, useNuxt, resolvePath } from "nuxt/kit";
+import type { ModuleOptions } from "./module";
+import { existsSync } from "node:fs";
+import { relative } from "node:path";
+
+/**
+ *
+ * @param cssPath
+ * @param nuxt
+ * @returns resolvedCSSPath
+ * @returns loggerMessage
+ * @example
+ * ```ts
+ * const { resolvedCSSPath, loggerMessage } = await resolveCSSPath('@/assets/css/global.css', nuxt);
+ * ```
+ */
+export async function resolveCSSPath(
+  cssPath: ModuleOptions["cssPath"],
+  nuxt = useNuxt()
+): Promise<{
+  resolvedCSSPath: NonNullable<ModuleOptions["cssPath"]>;
+  loggerMessage: string;
+}> {
+  const { resolve } = createResolver(import.meta.url);
+  const defaultCSSPath = `${nuxt.options.dir.assets}/css/global.css`;
+
+  const resolvedCSSPath =
+    typeof cssPath === "string"
+      ? await resolvePath(cssPath, { extensions: [".css"] })
+      : resolve(defaultCSSPath);
+
+  // TODO: if @/assets/css/global does not exist, throw error
+  // TODO: used panda css logger
+  return existsSync(resolvedCSSPath)
+    ? {
+        resolvedCSSPath,
+        loggerMessage: `🐼 [info] Using Panda CSS file from @/${relative(
+          nuxt.options.srcDir,
+          resolvedCSSPath
+        )}`,
+      }
+    : {
+        resolvedCSSPath,
+        loggerMessage: `🐼 [info] Using default Panda CSS file from @/${defaultCSSPath}`,
+      };
+}

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -27,6 +27,7 @@ describe("basic test", async () => {
     expect(config.exclude).toEqual([]);
     expect(config.outdir).toBe("styled-system");
     expect(config.cwd).toBe(nuxt.options.buildDir);
+    expect(config.cssPath).toBe(`${nuxt.options.buildDir}/panda.css`);
     expect(config.theme).toEqual({
       tokens: {
         colors: {


### PR DESCRIPTION
@wattanx 、こんにちは。素晴らしいモジュールに出会えたこと、幸運に思います。

本PRでは以下について追加対応致しました。お手隙の際にレビューよろしくお願い致します。

## 内容

### エラー遭遇・調査対応

モジュール追加時に以下のエラーに遭遇しました(下記エラーはブラウザの表示)

> [vite-node] [ERR_LOAD_URL] ./src/css/global.css

原因を調査したところ`css.push()`が上手くいっていないようでした。原因箇所を修正したところ、正常にモジュールを読み込めました。

https://github.com/wattanx/nuxt-pandacss/blob/52c4c98f9900a4fc5095f5a3862d0dd8d96e8844/src/module.ts#L65

CSSファイルパスはユーザーによって可変させたいニーズがあると考え、次項のような追加対応を行いました。

### Nuxt Module Optionsに `cssPath`を追加

#### 対応内容

- ユーザー未定義の場合はdefaultに対してCSSを自動生成。デフォルトは `<buildDir>/panda.css`を指定。
- cssPath用に`resolveCSSPath()`を実装。

#### 参考

- 本PRの実装は[Nuxt Tailwind](https://github.com/nuxt-modules/tailwindcss)からインスパイアを受けています
  - https://github.com/nuxt-modules/tailwindcss/blob/8ec24ca0b2f0ad6ad55e4facf67fe37232f97f31/src/types.ts

## 備考

`resolver()`のテストはどこまで書くべきか、テスト方針などあればご教示頂けると幸いです。
特に方針などないようであれば、別PRという形で適宜テスト実装、PR依頼を行います。

また、`@pandacss/*`および`nuxt/*`ライブラリのバージョンアップについてもご教示頂けると幸いです。