### PR TITLE
fix: settings are not reflected when settings configPath options.

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -14,6 +14,12 @@ import { resolveCSSPath } from "./resolvers";
 const logger = useLogger("nuxt:pandacss");
 
 export interface ModuleOptions extends Config {
+  /**
+   * The path of the Panda config file.
+   * If the file does not exist, it will be created automatically.
+   * @default '<buildDir>/panda.config.mjs'
+   * @example 'panda.config.ts'
+   */
   configPath?: string;
   /**
    * The path of the Panda CSS file.
@@ -56,7 +62,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     let configPath = "";
     try {
-      const configFile = findConfigFile({ cwd });
+      const configFile = findConfigFile({ cwd, file: options.configPath });
 
       configPath = configFile ?? addPandaConfigTemplate(cwd, options);
     } catch (e) {


### PR DESCRIPTION
@wattanx 

お手隙の際にレビューお願い致します。

## Issue

resolves #18 .

## Description

- [x] `findConfigFile()`の引数に`options.configPath`を追加
  - `findConfigFile(cwd: string , file?: string)`だったため、default.configPathの設定を追加していません。
  - default.configPath = "panda.config.mjs"とする場合は以下のチェックが必要になるかと思います。
      ```ts
      const configFile = findConfigFile({ cwd, file: options.configPath !== "panda.config.mjs" ? options.configPath : undefined });

      ```
- [x] ModuleOptionsにJSDocを追加